### PR TITLE
Remove duplicated Demo Pack featured link in Latest articles

### DIFF
--- a/index.md
+++ b/index.md
@@ -231,13 +231,6 @@ hide_tagline: false
     <h2>Community knowledge base</h2>
   </div>
 
-  <div class="featured-article-link" style="margin-bottom: 1.5em;">
-    <a class="primary-action" href="/community-articles/articles/github-copilot-dev-days-malta-demo-pack/">
-      <strong>GitHub Copilot Dev Days Malta &mdash; Technical Demo Pack</strong>
-    </a>
-    <span style="display:block; margin-top:0.5em;">Continue learning at your own pace with session-by-session demo runbooks and the workshop facilitation guide from GitHub Copilot Dev Days Malta 2026.</span>
-  </div>
-
 {% assign sorted_articles = site.articles | sort: "date" | reverse %}
 
 {% if sorted_articles.size > 0 %}


### PR DESCRIPTION
The hardcoded featured-article-link card duplicated the Demo Pack which already appears as the most recent entry in the auto-generated article list. Removed the hardcoded block so each article appears once.

Refs #7

## Article Submission

**Article title:** <!-- Title of the article -->

**Summary:** <!-- 1-2 sentence summary -->

**Target audience:** <!-- Beginner / Intermediate / Advanced -->

**Related issue:** <!-- e.g., Closes #12 or N/A -->

### Checklist

- [ ] Article is in `_articles/` with the `YYYY-MM-DD-slug.md` naming convention
- [ ] YAML frontmatter is complete (title, author, author_github, date, tags, description)
- [ ] Content follows the [CONTRIBUTING guidelines](../CONTRIBUTING.md)
- [ ] Images (if any) are in `assets/images/articles/<slug>/`
- [ ] I have read and agree to the [Code of Conduct](https://mmaug-org.github.io/maltamsaiusergroup/code-of-conduct.html)
