### PR TITLE
fix: add issues:write permission to both sync and archive workflows

### DIFF
--- a/.github/workflows/archive-past-events.yml
+++ b/.github/workflows/archive-past-events.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   archive:

--- a/.github/workflows/sync-upcoming-meetup-events.yml
+++ b/.github/workflows/sync-upcoming-meetup-events.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   sync:


### PR DESCRIPTION
Closes #28

## What

Adds `issues: write` to **both** nightly workflow permission blocks:
- `.github/workflows/sync-upcoming-meetup-events.yml`
- `.github/workflows/archive-past-events.yml`

## Why

Both workflows use `peter-evans/create-pull-request@v6` with a `labels:` option (`automation`, `content`). When those labels don't exist in the repository the action attempts to create them via the GitHub Labels API — which requires `issues: write`. That permission was missing from both workflows, causing every nightly run to fail at the "Open / update PR" step even though the Python scripts themselves succeeded.

**sync-upcoming-meetup-events**: runs 29–33 all fail (step 4 sync script = ✅, step 5 open PR = ❌)
**archive-past-events**: runs 38–42 all fail (same pattern)

## Change

```diff
 permissions:
   contents: write
   pull-requests: write
+  issues: write
```

Applied to both workflow files.

## Verification

The fix adds the single missing permission to each workflow; no script or logic changes.