### PR TITLE
feat: auto-archive past events without maintainer approval

### DIFF
--- a/.github/workflows/archive-past-events.yml
+++ b/.github/workflows/archive-past-events.yml
@@ -2,7 +2,7 @@ name: archive-past-events
 
 # Nightly check for events whose date has passed. If any are still listed
 # under the "Upcoming activities" carousel in index.md, the script moves
-# them into the "Past events" sidebar widget and opens a PR for review.
+# them into the "Past events" sidebar widget and commits directly to main.
 
 on:
   schedule:
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
-  issues: write
 
 jobs:
   archive:
@@ -33,30 +31,14 @@ jobs:
             echo "changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "changes=true" >> "$GITHUB_OUTPUT"
-            # Capture the script's summary line for the PR body.
             tail -n 1 /tmp/archive.log >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Open / update PR
+      - name: Commit and push
         if: steps.archive.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: chore/auto-archive-past-events
-          base: main
-          commit-message: "chore: archive expired upcoming events"
-          title: "chore: auto-archive past events"
-          body: |
-            Automated nightly run of `scripts/archive_past_events.py`.
-
-            One or more events listed under **Upcoming activities** have
-            a `data-event-date` earlier than today — they have been moved
-            into the **Past events** sidebar widget.
-
-            Please review the diff, add recording / recap links to each
-            archived item, then merge.
-
-            _Triggered by `.github/workflows/archive-past-events.yml`._
-          labels: |
-            automation
-            content
-          delete-branch: true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add index.md
+          git commit -m "chore: archive expired upcoming events [skip ci]"
+          git push


### PR DESCRIPTION
## What

Changes `archive-past-events.yml` to commit archived events directly to `main` instead of opening a PR for review.

## Why

Previously, the workflow opened a PR so a maintainer could add recording/recap links before merging. The new requirement is for archiving to happen automatically without approval.

## Change

- **Remove** `peter-evans/create-pull-request` step
- **Remove** `pull-requests: write` and `issues: write` permissions (no longer needed)
- **Add** a `Commit and push` step that configures the `github-actions[bot]` identity and pushes directly to `main`
- Commit message includes `[skip ci]` to prevent triggering downstream workflows in a loop

> **Note:** Recording and recap links will now need to be added to the Past events widget manually after the nightly archive runs.